### PR TITLE
Make:【サーバーサイド】Postテーブルを作成

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    //
+}

--- a/database/migrations/2021_09_03_184210_create_posts_table.php
+++ b/database/migrations/2021_09_03_184210_create_posts_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/migrations/2021_09_03_184210_create_posts_table.php
+++ b/database/migrations/2021_09_03_184210_create_posts_table.php
@@ -15,15 +15,19 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('title');
+            $table->string('content');
+            $table->string('category');
+            $table->unsignedBigInteger('user_id');
             $table->timestamps();
+
+            $table->foreign('user_id')
+                    ->references('id')
+                    ->on('users')
+                    ->onDelete('cascade');
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
     public function down()
     {
         Schema::dropIfExists('posts');

--- a/database/migrations/2021_09_03_184210_create_posts_table.php
+++ b/database/migrations/2021_09_03_184210_create_posts_table.php
@@ -6,11 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 class CreatePostsTable extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {


### PR DESCRIPTION
# What
Postテーブルを作成する。
- ターミナルでphp artisan make:model Post -mを実行する（-mをつけるとpostモデルも同時に作成される）
- migrationファイルを作成する（usersテーブルとpostテーブルは１対多の関係にあるので外部キー制約を追加した）

# Why
ユーザーの投稿を管理するため。